### PR TITLE
Search query

### DIFF
--- a/README.md
+++ b/README.md
@@ -171,9 +171,6 @@ To simply return all tests (there is a default limit of 250):
 GET /tests
 Content-Type: application/json
 ```
-``` json
-{}
-```
 
 Responses look like:
 
@@ -199,7 +196,47 @@ Content-Type: application/json
 }
 ```
 
+#### Querying for tests
+Querying for tests can be done with the GET /tests endpoint. To send any query, what you first must do is encode your 
+query payload in base64 and send it as a query string. This is for compliance with OpenAPI V3 and HTTP 1.1. 
+There is an endpoint to encode a TestQuery payload for you:
+
+```
+POST /query
+Content-Type: application/json
+```
+```json
+{
+  "resolutions": ["QuickFix", "TicketCreated"]
+}
+```
+
+This will return a query string like the following:
+```
+"eyJyZXNvbHV0aW9ucyI6WyJRdWlja0ZpeCIsIlRpY2tldENyZWF0ZWQiXX0K"
+```
+
+You can now take this query and use it with the GET endpoint:
+
+```
+GET http://localhost:8080/tests?query=eyJyZXNvbHV0aW9ucyI6WyJRdWlja0ZpeCIsIlRpY2tldENyZWF0ZWQiXX0K
+```
+Response:
+```json
+{
+  "count": 4,
+  "tests": []
+}
+```
+
+An FYI, you can use the same query to delete tests also:
+```
+DELETE http://localhost:8080/tests?query=eyJyZXNvbHV0aW9ucyI6WyJRdWlja0ZpeCIsIlRpY2tldENyZWF0ZWQiXX0K
+```
+
 Each filter option (with the exceptions of the time filters) take arrays as inputs.
+
+**NOTE**: For simplicity, I will leave out the intermediate step of encoding a query for the rest of this guide.
 
 Querying with multiple values in an array will be treated as a logical "OR". For example, if I wanted to query for all 
 tests that resulted in a quick fix or a ticket creation, I can send the following request:
@@ -210,7 +247,7 @@ Content-Type: application/json
 ```
 ``` json
 {
-    resolutions: ["QuickFix", "TicketCreated"]
+    "resolutions": ["QuickFix", "TicketCreated"]
 }
 ```
 
@@ -222,8 +259,8 @@ Content-Type: application/json
 ```
 ``` json
 {
-    analyses: ["TruePositive"]
-    resolutions: ["QuickFix", "TicketCreated"]
+    "analyses": ["TruePositive"]
+    "resolutions": ["QuickFix", "TicketCreated"]
 }
 ```
 

--- a/service/base64.go
+++ b/service/base64.go
@@ -1,0 +1,28 @@
+package main
+
+import (
+	"bytes"
+	"encoding/base64"
+	"encoding/json"
+	"strings"
+)
+
+// encodeToBase64 will take a value that is JSON encodable and encode it with base64.
+func encodeToBase64(v any) (string, error) {
+	var buf bytes.Buffer
+	encoder := base64.NewEncoder(base64.StdEncoding, &buf)
+	err := json.NewEncoder(encoder).Encode(v)
+	if err != nil {
+		return "", err
+	}
+	err = encoder.Close()
+	if err != nil {
+		return "", err
+	}
+	return buf.String(), nil
+}
+
+// decodeFromBase64 can take a v struct and decode a base64 encoded string into it.
+func decodeFromBase64(v any, enc string) error {
+	return json.NewDecoder(base64.NewDecoder(base64.StdEncoding, strings.NewReader(enc))).Decode(v)
+}

--- a/service/controllers.go
+++ b/service/controllers.go
@@ -1,13 +1,11 @@
 package main
 
 import (
-	"encoding/json"
 	"errors"
 	"github.com/gin-gonic/gin"
 	"github.com/jackc/pgx"
 	"net/http"
 	"strconv"
-	"strings"
 )
 
 // TestController will maintain a database pool for all test controllers
@@ -80,20 +78,33 @@ func (tc *TestController) PatchTest(c *gin.Context) {
 	c.Status(http.StatusOK)
 }
 
-// DeleteTests is a bulk endpoint that can mark tests as deleted. These tests will no longer be visible from the UI, but
-// will still remain in the DB unless manually removed just-in-case they need to be recovered.
+// DeleteTests takes in a TestQuery and will delete all the query results
 // DeleteTests will silently ignore if the caller passes in test IDs that already don't exist.
 // DeleteTests will respond with a http.StatusNotModified (304) status code if it does not delete a single test.
 // DeleteTests will respond with a http.StatusOK (200) status code if it deletes at least 1 test.
 func (tc *TestController) DeleteTests(c *gin.Context) {
-	var testsToDelete []Test
+	var query TestQuery
 
-	if err := c.BindJSON(&testsToDelete); err != nil {
+	encodedQuery := c.DefaultQuery("query", "null")
+	if encodedQuery == "null" {
+		c.JSON(http.StatusBadRequest, ConvertErrToGinH(errors.New("must pass a query parameter")))
+		return
+	}
+
+	err := decodeFromBase64(&query, encodedQuery)
+	if err != nil {
 		c.JSON(http.StatusBadRequest, ConvertErrToGinH(err))
 		return
 	}
+
+	queryResult, err := QueryTest(tc.DBPool, &query, 250, 0)
+	if err != nil {
+		c.JSON(http.StatusBadRequest, ConvertErrToGinH(err))
+		return
+	}
+
 	var testIDsToDelete []uint64
-	for _, testToDelete := range testsToDelete {
+	for _, testToDelete := range queryResult.Tests {
 		testIDsToDelete = append(testIDsToDelete, testToDelete.ID)
 	}
 
@@ -136,112 +147,21 @@ func (tc *TestController) GetTests(c *gin.Context) {
 		return
 	}
 
-	encodedQuery := c.DefaultQuery("search", "null")
-	if encodedQuery == "null" {
-		c.JSON(http.StatusBadRequest, ConvertErrToGinH(errors.New("must pass a query parameter")))
-		return
+	encodedQuery := c.DefaultQuery("query", "null")
+	if encodedQuery != "null" {
+		err = decodeFromBase64(&query, encodedQuery)
+		if err != nil {
+			c.JSON(http.StatusBadRequest, ConvertErrToGinH(err))
+			return
+		}
 	}
-	err = decodeFromBase64(&query, encodedQuery)
+
+	queryResult, err := QueryTest(tc.DBPool, &query, limit, offset)
 	if err != nil {
 		c.JSON(http.StatusBadRequest, ConvertErrToGinH(err))
 		return
 	}
-
-	// Build query
-	var wheres []string // Will contain all the "WHERE" clauses
-	var params []any    // These are the parameters to pass for the SQL prepared statement
-
-	SQL := "SELECT * FROM OAR_TESTS"
-	if len(query.IDs) > 0 {
-		wheres = append(wheres, "ID = ANY($)")
-		params = append(params, query.IDs)
-	}
-
-	if len(query.Summaries) > 0 {
-		wheres = append(wheres, "SUMMARY ~* "+"'"+strings.Join(query.Summaries, "|")+"'")
-	}
-
-	if len(query.Outcomes) > 0 {
-		wheres = append(wheres, "OUTCOME = ANY($)")
-		params = append(params, query.Outcomes)
-	}
-
-	if len(query.Analyses) > 0 {
-		wheres = append(wheres, "ANALYSIS = ANY($)")
-		params = append(params, query.Analyses)
-	}
-
-	if len(query.Resolutions) > 0 {
-		wheres = append(wheres, "RESOLUTION = ANY($)")
-		params = append(params, query.Resolutions)
-	}
-
-	if query.CreatedBefore != nil {
-		wheres = append(wheres, "CREATED < $")
-		params = append(params, query.CreatedBefore)
-	}
-
-	if query.CreatedAfter != nil {
-		wheres = append(wheres, "CREATED > $")
-		params = append(params, query.CreatedAfter)
-	}
-
-	if query.ModifiedBefore != nil {
-		wheres = append(wheres, "MODIFIED < $")
-		params = append(params, query.ModifiedBefore)
-	}
-
-	if query.ModifiedAfter != nil {
-		wheres = append(wheres, "MODIFIED > $")
-		params = append(params, query.ModifiedAfter)
-	}
-
-	if len(query.Docs) > 0 {
-		docQuery := "("
-		for i, doc := range query.Docs {
-			if i == 0 {
-				docQuery += "doc @> '$'"
-			} else {
-				docQuery += " " + "OR" + " " + "doc @> '$'"
-			}
-			strDoc, err := json.Marshal(doc)
-			if err != nil {
-				c.JSON(http.StatusBadRequest, ConvertErrToGinH(err))
-				return
-			}
-			docQuery = strings.Replace(docQuery, "$", string(strDoc), 1)
-		}
-		docQuery += ")"
-		wheres = append(wheres, docQuery)
-	}
-
-	for i, where := range wheres {
-		where = strings.Replace(where, "$", "$"+strconv.Itoa(i+1), 1) // formats string replacement params
-		if i == 0 {
-			SQL += " " + "WHERE" + " " + where
-		} else {
-			SQL += " " + "AND" + " " + where
-		}
-	}
-
-	// Orders by the most recently modified tests being first
-	SQL += " " + "ORDER BY MODIFIED DESC"
-
-	// Add offset and limit
-	SQL += " " + "OFFSET " + strconv.Itoa(offset) + " " + "LIMIT" + " " + strconv.Itoa(limit)
-
-	tests, err := SelectTests(tc.DBPool, SQL, params...)
-	if err != nil {
-		c.JSON(http.StatusBadRequest, ConvertErrToGinH(err))
-		return
-	}
-
-	if tests == nil {
-		tests = []*Test{}
-	}
-
-	response := TestQueryResponse{Count: uint64(len(tests)), Tests: tests}
-	c.JSON(200, response)
+	c.JSON(200, queryResult)
 }
 
 // EncodeSearchQuery will take a TestQuery as a body and encode it in base64 to send to the GET endpoint.

--- a/service/controllers.go
+++ b/service/controllers.go
@@ -237,3 +237,25 @@ func (tc *TestController) GetTests(c *gin.Context) {
 	response := TestQueryResponse{Count: uint64(len(tests)), Tests: tests}
 	c.JSON(200, response)
 }
+
+// EncodeSearchQuery will take a TestQuery as a body and encode it in base64 to send to the GET endpoint.
+// This is an intermediate step for 2 reasons:
+//
+// 1.) By encoding the request, it allows for a complex search query language without complex GET URL params.
+// I had originally made the GET endpoint take a request body, but that is not by HTTP 1.1 spec.
+//
+// 2.) This will also allow search queries to be sent via url which will be helpful.
+func EncodeSearchQuery(c *gin.Context) {
+	var query TestQuery
+	if err := c.BindJSON(&query); err != nil {
+		c.JSON(http.StatusBadRequest, ConvertErrToGinH(err))
+		return
+	}
+
+	encodedString, err := encodeToBase64(query)
+	if err != nil {
+		c.JSON(http.StatusBadRequest, ConvertErrToGinH(err))
+		return
+	}
+	c.JSON(200, encodedString)
+}

--- a/service/controllers.go
+++ b/service/controllers.go
@@ -136,7 +136,13 @@ func (tc *TestController) GetTests(c *gin.Context) {
 		return
 	}
 
-	if err := c.BindJSON(&query); err != nil {
+	encodedQuery := c.DefaultQuery("search", "null")
+	if encodedQuery == "null" {
+		c.JSON(http.StatusBadRequest, ConvertErrToGinH(errors.New("must pass a query parameter")))
+		return
+	}
+	err = decodeFromBase64(&query, encodedQuery)
+	if err != nil {
 		c.JSON(http.StatusBadRequest, ConvertErrToGinH(err))
 		return
 	}

--- a/service/controllers_test.go
+++ b/service/controllers_test.go
@@ -1,10 +1,8 @@
 package main
 
 import (
-	"bytes"
 	"encoding/json"
 	"fmt"
-	"github.com/gin-gonic/gin"
 	"github.com/jackc/pgx"
 	"github.com/magiconair/properties/assert"
 	"net/http"
@@ -104,17 +102,26 @@ func TestTestController_DeleteTests(t *testing.T) {
 
 	testID, err := InsertTest(Fake.pgPool(), Fake.test())
 	testID2, err := InsertTest(Fake.pgPool(), Fake.test())
-	body := []gin.H{
-		{"ID": testID},
-		{"ID": testID2},
+
+	query := TestQuery{
+		IDs:            []uint64{testID, testID2},
+		Summaries:      nil,
+		Outcomes:       nil,
+		Analyses:       nil,
+		Resolutions:    nil,
+		CreatedBefore:  nil,
+		CreatedAfter:   nil,
+		ModifiedBefore: nil,
+		ModifiedAfter:  nil,
+		Docs:           nil,
 	}
-	jsonValue, err := json.Marshal(body)
+	encodedQuery, err := encodeToBase64(query)
 	if err != nil {
-		t.Error("setup error", err)
+		t.Error(err)
 	}
 
 	t.Run("delete tests that exist", func(t *testing.T) {
-		req, err := http.NewRequest(http.MethodDelete, "/tests", bytes.NewBuffer(jsonValue))
+		req, err := http.NewRequest(http.MethodDelete, "/tests?query="+encodedQuery, nil)
 		if err != nil {
 			t.Error("setup error", err)
 		}
@@ -123,12 +130,11 @@ func TestTestController_DeleteTests(t *testing.T) {
 
 		c.Request = req
 		controller.DeleteTests(c)
-
 		assert.Equal(t, w.Code, 200)
 	})
 
 	t.Run("delete tests that don't exist", func(t *testing.T) {
-		req, err := http.NewRequest(http.MethodDelete, "/tests", bytes.NewBuffer(jsonValue))
+		req, err := http.NewRequest(http.MethodDelete, "/tests?query="+encodedQuery, nil)
 		if err != nil {
 			t.Error("setup error", err)
 		}
@@ -136,20 +142,14 @@ func TestTestController_DeleteTests(t *testing.T) {
 		c, w := Fake.ginContext()
 
 		c.Request = req
+
 		controller.DeleteTests(c)
 
-		assert.Equal(t, w.Code, 200)
+		assert.Equal(t, w.Code, http.StatusOK)
 	})
 
-	t.Run("delete with just ids", func(t *testing.T) {
-		body := []uint64{testID, testID2}
-
-		jsonValue, err = json.Marshal(body)
-		if err != nil {
-			t.Error("setup error", err)
-		}
-
-		req, err := http.NewRequest(http.MethodDelete, "/tests", bytes.NewBuffer(jsonValue))
+	t.Run("delete with no query", func(t *testing.T) {
+		req, err := http.NewRequest(http.MethodDelete, "/tests", nil)
 		if err != nil {
 			t.Error("setup error", err)
 		}
@@ -326,17 +326,18 @@ func TestTestController_GetTests(t *testing.T) {
 			ModifiedAfter:  nil,
 			Docs:           nil,
 		}
-
-		requestBody, err := json.Marshal(query)
+		encodedQuery, err := encodeToBase64(query)
 		if err != nil {
-			t.Error("setup error", err)
+			t.Error("setup error")
 		}
-		req, err := http.NewRequest(http.MethodGet, "/tests", bytes.NewBuffer(requestBody))
+
+		req, err := http.NewRequest(http.MethodGet, "/tests?query="+encodedQuery, nil)
 		if err != nil {
 			t.Error("setup error", err)
 		}
 
 		c.Request = req
+
 		controller.GetTests(c)
 		assert.Equal(t, w.Code, 200)
 
@@ -370,21 +371,22 @@ func TestTestController_GetTests(t *testing.T) {
 			ModifiedAfter:  nil,
 			Docs:           nil,
 		}
-
-		requestBody, err := json.Marshal(query)
+		encodedQuery, err := encodeToBase64(query)
 		if err != nil {
-			t.Error("setup error", err)
+			t.Error("setup error")
 		}
+
 		req, err := http.NewRequest(
 			http.MethodGet,
-			"/tests?limit="+strconv.Itoa(numTests-2)+"&offset=3",
-			bytes.NewBuffer(requestBody),
+			"/tests?query="+encodedQuery+"&limit="+strconv.Itoa(numTests-2)+"&offset=3",
+			nil,
 		)
 		if err != nil {
 			t.Error("setup error", err)
 		}
 
 		c.Request = req
+
 		controller.GetTests(c)
 		assert.Equal(t, w.Code, 200)
 
@@ -418,17 +420,18 @@ func TestTestController_GetTests(t *testing.T) {
 			ModifiedAfter:  nil,
 			Docs:           nil,
 		}
-
-		requestBody, err := json.Marshal(query)
+		encodedQuery, err := encodeToBase64(query)
 		if err != nil {
-			t.Error("setup error", err)
+			t.Error("setup error")
 		}
-		req, err := http.NewRequest(http.MethodGet, "/tests", bytes.NewBuffer(requestBody))
+
+		req, err := http.NewRequest(http.MethodGet, "/tests?query="+encodedQuery, nil)
 		if err != nil {
 			t.Error("setup error", err)
 		}
 
 		c.Request = req
+
 		controller.GetTests(c)
 		assert.Equal(t, w.Code, 200)
 
@@ -463,17 +466,18 @@ func TestTestController_GetTests(t *testing.T) {
 			ModifiedAfter:  nil,
 			Docs:           nil,
 		}
-
-		requestBody, err := json.Marshal(query)
+		encodedQuery, err := encodeToBase64(query)
 		if err != nil {
-			t.Error("setup error", err)
+			t.Error("setup error")
 		}
-		req, err := http.NewRequest(http.MethodGet, "/tests", bytes.NewBuffer(requestBody))
+
+		req, err := http.NewRequest(http.MethodGet, "/tests?query="+encodedQuery, nil)
 		if err != nil {
 			t.Error("setup error", err)
 		}
 
 		c.Request = req
+
 		controller.GetTests(c)
 		assert.Equal(t, w.Code, 200)
 
@@ -504,17 +508,18 @@ func TestTestController_GetTests(t *testing.T) {
 			ModifiedAfter:  nil,
 			Docs:           nil,
 		}
-
-		requestBody, err := json.Marshal(query)
+		encodedQuery, err := encodeToBase64(query)
 		if err != nil {
-			t.Error("setup error", err)
+			t.Error("setup error")
 		}
-		req, err := http.NewRequest(http.MethodGet, "/tests?limit=1001", bytes.NewBuffer(requestBody))
+
+		req, err := http.NewRequest(http.MethodGet, "/tests?limit=1001&query="+encodedQuery, nil)
 		if err != nil {
 			t.Error("setup error", err)
 		}
 
 		c.Request = req
+
 		controller.GetTests(c)
 		assert.Equal(t, w.Code, 400)
 	})
@@ -536,18 +541,18 @@ func TestTestController_GetTests(t *testing.T) {
 			ModifiedAfter:  nil,
 			Docs:           nil,
 		}
-
-		requestBody, err := json.Marshal(query)
+		encodedQuery, err := encodeToBase64(query)
 		if err != nil {
-			t.Error("setup error", err)
+			t.Error("setup error")
 		}
 
-		req, err := http.NewRequest(http.MethodGet, "/tests", bytes.NewBuffer(requestBody))
+		req, err := http.NewRequest(http.MethodGet, "/tests?query="+encodedQuery, nil)
 		if err != nil {
 			t.Error("setup error", err)
 		}
 
 		c.Request = req
+
 		controller.GetTests(c)
 		assert.Equal(t, w.Code, 200)
 
@@ -579,18 +584,18 @@ func TestTestController_GetTests(t *testing.T) {
 			ModifiedAfter:  nil,
 			Docs:           nil,
 		}
-
-		requestBody, err := json.Marshal(query)
+		encodedQuery, err := encodeToBase64(query)
 		if err != nil {
-			t.Error("setup error", err)
+			t.Error("setup error")
 		}
 
-		req, err := http.NewRequest(http.MethodGet, "/tests", bytes.NewBuffer(requestBody))
+		req, err := http.NewRequest(http.MethodGet, "/tests?query="+encodedQuery, nil)
 		if err != nil {
 			t.Error("setup error", err)
 		}
 
 		c.Request = req
+
 		controller.GetTests(c)
 		assert.Equal(t, w.Code, 200)
 
@@ -622,18 +627,18 @@ func TestTestController_GetTests(t *testing.T) {
 			ModifiedAfter:  nil,
 			Docs:           nil,
 		}
-
-		requestBody, err := json.Marshal(query)
+		encodedQuery, err := encodeToBase64(query)
 		if err != nil {
-			t.Error("setup error", err)
+			t.Error("setup error")
 		}
 
-		req, err := http.NewRequest(http.MethodGet, "/tests", bytes.NewBuffer(requestBody))
+		req, err := http.NewRequest(http.MethodGet, "/tests?query="+encodedQuery, nil)
 		if err != nil {
 			t.Error("setup error", err)
 		}
 
 		c.Request = req
+
 		controller.GetTests(c)
 		assert.Equal(t, w.Code, 200)
 
@@ -665,18 +670,18 @@ func TestTestController_GetTests(t *testing.T) {
 			ModifiedAfter:  &yesterday,
 			Docs:           nil,
 		}
-
-		requestBody, err := json.Marshal(query)
+		encodedQuery, err := encodeToBase64(query)
 		if err != nil {
-			t.Error("setup error", err)
+			t.Error("setup error")
 		}
 
-		req, err := http.NewRequest(http.MethodGet, "/tests", bytes.NewBuffer(requestBody))
+		req, err := http.NewRequest(http.MethodGet, "/tests?query="+encodedQuery, nil)
 		if err != nil {
 			t.Error("setup error", err)
 		}
 
 		c.Request = req
+
 		controller.GetTests(c)
 		assert.Equal(t, w.Code, 200)
 
@@ -709,18 +714,18 @@ func TestTestController_GetTests(t *testing.T) {
 			ModifiedAfter:  nil,
 			Docs:           []map[string]any{genTest.Doc, genTest2.Doc},
 		}
-
-		requestBody, err := json.Marshal(query)
+		encodedQuery, err := encodeToBase64(query)
 		if err != nil {
-			t.Error("setup error", err)
+			t.Error("setup error")
 		}
 
-		req, err := http.NewRequest(http.MethodGet, "/tests", bytes.NewBuffer(requestBody))
+		req, err := http.NewRequest(http.MethodGet, "/tests?query="+encodedQuery, nil)
 		if err != nil {
 			t.Error("setup error", err)
 		}
 
 		c.Request = req
+
 		controller.GetTests(c)
 		assert.Equal(t, w.Code, 200)
 
@@ -754,18 +759,18 @@ func TestTestController_GetTests(t *testing.T) {
 			ModifiedAfter:  nil,
 			Docs:           nil,
 		}
-
-		requestBody, err := json.Marshal(query)
+		encodedQuery, err := encodeToBase64(query)
 		if err != nil {
-			t.Error("setup error", err)
+			t.Error("setup error")
 		}
 
-		req, err := http.NewRequest(http.MethodGet, "/tests", bytes.NewBuffer(requestBody))
+		req, err := http.NewRequest(http.MethodGet, "/tests?query="+encodedQuery, nil)
 		if err != nil {
 			t.Error("setup error", err)
 		}
 
 		c.Request = req
+
 		controller.GetTests(c)
 		assert.Equal(t, w.Code, 200)
 

--- a/service/main.go
+++ b/service/main.go
@@ -47,6 +47,8 @@ func GetRouter() *gin.Engine {
 		c.JSON(http.StatusOK, gin.H{"health": "healthy"})
 		return
 	})
+
+	r.POST("/query", EncodeSearchQuery)
 	return r
 }
 

--- a/service/main_test.go
+++ b/service/main_test.go
@@ -44,6 +44,12 @@ func TestGetRouter(t *testing.T) {
 			HandlerFunc: nil,
 		},
 		{
+			Method:      http.MethodPost,
+			Path:        "/query",
+			Handler:     "github.com/ryandem1/oar.EncodeSearchQuery",
+			HandlerFunc: nil,
+		},
+		{
 			Method:      http.MethodPatch,
 			Path:        "/test",
 			Handler:     "github.com/ryandem1/oar.(*TestController).PatchTest-fm",

--- a/service/service.go
+++ b/service/service.go
@@ -1,0 +1,107 @@
+package main
+
+import (
+	"encoding/json"
+	"github.com/jackc/pgx"
+	"strconv"
+	"strings"
+)
+
+// QueryTest will take a DB connection pool to the OAR DB, parse the query, apply the limit and offset and return
+// the query response.
+// See GetTests for more info
+func QueryTest(dbPool *pgx.ConnPool, query *TestQuery, limit int, offset int) (*TestQueryResponse, error) {
+	// Build query
+	var wheres []string // Will contain all the "WHERE" clauses
+	var params []any    // These are the parameters to pass for the SQL prepared statement
+
+	SQL := "SELECT * FROM OAR_TESTS"
+	if len(query.IDs) > 0 {
+		wheres = append(wheres, "ID = ANY($)")
+		params = append(params, query.IDs)
+	}
+
+	if query != nil && len(query.Summaries) > 0 {
+		wheres = append(wheres, "SUMMARY ~* "+"'"+strings.Join(query.Summaries, "|")+"'")
+	}
+
+	if query != nil && len(query.Outcomes) > 0 {
+		wheres = append(wheres, "OUTCOME = ANY($)")
+		params = append(params, query.Outcomes)
+	}
+
+	if query != nil && len(query.Analyses) > 0 {
+		wheres = append(wheres, "ANALYSIS = ANY($)")
+		params = append(params, query.Analyses)
+	}
+
+	if query != nil && len(query.Resolutions) > 0 {
+		wheres = append(wheres, "RESOLUTION = ANY($)")
+		params = append(params, query.Resolutions)
+	}
+
+	if query != nil && query.CreatedBefore != nil {
+		wheres = append(wheres, "CREATED < $")
+		params = append(params, query.CreatedBefore)
+	}
+
+	if query != nil && query.CreatedAfter != nil {
+		wheres = append(wheres, "CREATED > $")
+		params = append(params, query.CreatedAfter)
+	}
+
+	if query != nil && query.ModifiedBefore != nil {
+		wheres = append(wheres, "MODIFIED < $")
+		params = append(params, query.ModifiedBefore)
+	}
+
+	if query != nil && query.ModifiedAfter != nil {
+		wheres = append(wheres, "MODIFIED > $")
+		params = append(params, query.ModifiedAfter)
+	}
+
+	if query != nil && len(query.Docs) > 0 {
+		docQuery := "("
+		for i, doc := range query.Docs {
+			if i == 0 {
+				docQuery += "doc @> '$'"
+			} else {
+				docQuery += " " + "OR" + " " + "doc @> '$'"
+			}
+			strDoc, err := json.Marshal(doc)
+			if err != nil {
+				return nil, err
+			}
+			docQuery = strings.Replace(docQuery, "$", string(strDoc), 1)
+		}
+		docQuery += ")"
+		wheres = append(wheres, docQuery)
+	}
+
+	for i, where := range wheres {
+		where = strings.Replace(where, "$", "$"+strconv.Itoa(i+1), 1) // formats string replacement params
+		if i == 0 {
+			SQL += " " + "WHERE" + " " + where
+		} else {
+			SQL += " " + "AND" + " " + where
+		}
+	}
+
+	// Orders by the most recently modified tests being first
+	SQL += " " + "ORDER BY MODIFIED DESC"
+
+	// Add offset and limit
+	SQL += " " + "OFFSET " + strconv.Itoa(offset) + " " + "LIMIT" + " " + strconv.Itoa(limit)
+
+	tests, err := SelectTests(dbPool, SQL, params...)
+	if err != nil {
+		return nil, err
+	}
+
+	if tests == nil {
+		tests = []*Test{}
+	}
+
+	response := &TestQueryResponse{Count: uint64(len(tests)), Tests: tests}
+	return response, nil
+}


### PR DESCRIPTION
Added endpoint to base64 encode queries and updated GET and DELETE methods to take in the queries instead of request bodies for OpenAPI v3 and HTTP 1.1 compliance.