### PR TITLE
Fixed patch endpoint

### DIFF
--- a/service/controllers.go
+++ b/service/controllers.go
@@ -59,6 +59,11 @@ func (tc *TestController) PatchTest(c *gin.Context) {
 		return
 	}
 
+	if len(tests) < 1 {
+		c.JSON(http.StatusBadRequest, ConvertErrToGinH(errors.New("no test found with that id")))
+		return
+	}
+
 	test := tests[0]
 	test.Merge(testPatch)
 


### PR DESCRIPTION
The enrich endpoint would panic if the test ID didn't exist, this fixes that